### PR TITLE
check will crash the editor if run with a robot placed in world

### DIFF
--- a/Source/rclUE/Private/ROS2Node.cpp
+++ b/Source/rclUE/Private/ROS2Node.cpp
@@ -96,13 +96,13 @@ void AROS2Node::AddSubscription(const FString& TopicName,
 {
     check(State == UROS2State::Initialized);
 
-    bool SubExists = false;
     for (auto& s : Subscriptions)
     {
-        SubExists |= (s.TopicName == TopicName);
+        if( s.TopicName != TopicName ) continue;
+        
+        UE_LOG(LogROS2Node, Warning, TEXT("ROS2Node::AddSubscription - already subscribed to [%s]"), *s.TopicName );
+        return;
     }
-
-    check(!SubExists);
 
     if (!Callback.IsBound())
     {


### PR DESCRIPTION
subscription to cmd_vel is done twice apparently when the robot is placed in the world and simulation is run. 
This resulted in editor crashing.
I think it's better to avoid crash and just ignore the duplicated subscription request with a log warning.