### PR TITLE
Update github-cherry-pick-action to v1.0.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       if: matrix.version != github.base_ref
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
+      uses: carloscastrojumo/github-cherry-pick-action@v1.0.10
       with:
         branch: ${{ matrix.version }}
         labels: |


### PR DESCRIPTION
update github-cherry-pick-action to v1.0.10


switch do node20 (previus version deprecated)