### PR TITLE
fix action status

### DIFF
--- a/Source/rclUE/Private/ROS2ActionClient.cpp
+++ b/Source/rclUE/Private/ROS2ActionClient.cpp
@@ -95,7 +95,7 @@ void UROS2ActionClient::ProcessReady(rcl_wait_set_t* wait_set)
         if (Ret != RCL_RET_OK)
         {
             const rcl_error_string_t RclErrorString = rcl_get_error_string();
-            UE_LOG_WITH_INFO(LogROS2Action, Error, TEXT("rcl_action_take_status failed: %s"), UTF8_TO_TCHAR(RclErrorString.str));
+            UE_LOG_WITH_INFO(LogROS2Action, Error, TEXT("rcl_action_take_status failed for action %s: %s"), *ActionName, UTF8_TO_TCHAR(RclErrorString.str));
             rcl_reset_error();
         }
         else

--- a/Source/rclUE/Private/ROS2ActionClient.cpp
+++ b/Source/rclUE/Private/ROS2ActionClient.cpp
@@ -3,6 +3,7 @@
 #include "ROS2ActionClient.h"
 
 #include "rclcUtilities.h"
+#include "rcl/error_handling.h"
 
 UROS2ActionClient* UROS2ActionClient::CreateActionClient(UObject* InOwner,
                                                          const FString& InActionName,
@@ -14,7 +15,8 @@ UROS2ActionClient* UROS2ActionClient::CreateActionClient(UObject* InOwner,
                                                          const UROS2QoS InGoalQoS,
                                                          const UROS2QoS InResultQoS,
                                                          const UROS2QoS InFeedbackQoS,
-                                                         const UROS2QoS InCancelQoS)
+                                                         const UROS2QoS InCancelQoS,
+                                                         const UROS2QoS InStatusQoS)
 {
     UROS2ActionClient* client = NewObject<UROS2ActionClient>(InOwner);
     client->ActionClass = InActionClass;
@@ -23,6 +25,7 @@ UROS2ActionClient* UROS2ActionClient::CreateActionClient(UObject* InOwner,
     client->ResultQoS = InResultQoS;
     client->FeedbackQoS = InFeedbackQoS;
     client->CancelQoS = InCancelQoS;
+    client->StatusQoS = InStatusQoS;
     client->SetDelegates(InFeedbackDelegate, InResultResponseDelegate, InGoalResponseDelegate, InCancelResponseDelegate);
     return client;
 }
@@ -38,7 +41,7 @@ void UROS2ActionClient::InitializeActionComponent()
     client_opt.result_service_qos = QoS_LUT[ResultQoS];
     client_opt.cancel_service_qos = QoS_LUT[CancelQoS];
     client_opt.feedback_topic_qos = QoS_LUT[FeedbackQoS];
-    client_opt.status_topic_qos = QoS_LUT[UROS2QoS::Default];    // status is not supported yet.
+    client_opt.status_topic_qos = QoS_LUT[StatusQoS];
 
     rcl_ret_t rc =
         rcl_action_client_init(&client, OwnerNode->GetNode(), action_type_support, TCHAR_TO_UTF8(*ActionName), &client_opt);
@@ -79,8 +82,44 @@ void UROS2ActionClient::ProcessReady(rcl_wait_set_t* wait_set)
 
     if (IsReady[1])
     {
-        ensureMsgf(false, TEXT("Action Client take status not implemented yet"));
+        UE_LOG_WITH_INFO(LogROS2Action, Log, TEXT("2. Action Client - Attempting to take goal status message"));
+
+        action_msgs__msg__GoalStatusArray StatusMsg;
+        if (!action_msgs__msg__GoalStatusArray__init(&StatusMsg))
+        {
+            UE_LOG_WITH_INFO(LogROS2Action, Error, TEXT("Failed to initialize GoalStatusArray message"));
+            return;
+        }
+
+        rcl_ret_t Ret = rcl_action_take_status(&client, &StatusMsg);
+        if (Ret != RCL_RET_OK)
+        {
+            const rcl_error_string_t ErrorStr = rcl_get_error_string();
+            UE_LOG_WITH_INFO(LogROS2Action, Error, TEXT("rcl_action_take_status failed: %s"), UTF8_TO_TCHAR(ErrorStr.str));
+            rcl_reset_error();
+        }
+        else
+        {
+            UE_LOG_WITH_INFO(LogROS2Action, Log, TEXT(" → Received %d goal status entries"), StatusMsg.status_list.size);
+
+            for (size_t i = 0; i < StatusMsg.status_list.size; ++i)
+            {
+                const action_msgs__msg__GoalStatus& GoalStatus = StatusMsg.status_list.data[i];
+
+                FString UuidStr;
+                for (int j = 0; j < 16; ++j)
+                {
+                    UuidStr += FString::Printf(TEXT("%02X"), GoalStatus.goal_info.goal_id.uuid[j]);
+                }
+
+                FString StatusStr = FString::Printf(TEXT("Goal %s has status %d"), *UuidStr, GoalStatus.status);
+                UE_LOG_WITH_INFO(LogROS2Action, Log, TEXT(" → %s"), *StatusStr);
+            }
+        }
+
+        action_msgs__msg__GoalStatusArray__fini(&StatusMsg);
     }
+
 
     if (IsReady[2])
     {

--- a/Source/rclUE/Private/ROS2ActionClient.cpp
+++ b/Source/rclUE/Private/ROS2ActionClient.cpp
@@ -94,8 +94,8 @@ void UROS2ActionClient::ProcessReady(rcl_wait_set_t* wait_set)
         rcl_ret_t Ret = rcl_action_take_status(&client, &StatusMsg);
         if (Ret != RCL_RET_OK)
         {
-            const rcl_error_string_t ErrorStr = rcl_get_error_string();
-            UE_LOG_WITH_INFO(LogROS2Action, Error, TEXT("rcl_action_take_status failed: %s"), UTF8_TO_TCHAR(ErrorStr.str));
+            const rcl_error_string_t RclErrorString = rcl_get_error_string();
+            UE_LOG_WITH_INFO(LogROS2Action, Error, TEXT("rcl_action_take_status failed: %s"), UTF8_TO_TCHAR(RclErrorString.str));
             rcl_reset_error();
         }
         else

--- a/Source/rclUE/Private/ROS2ActionServer.cpp
+++ b/Source/rclUE/Private/ROS2ActionServer.cpp
@@ -13,7 +13,8 @@ UROS2ActionServer* UROS2ActionServer::CreateActionServer(UObject* InOwner,
                                                          const UROS2QoS InGoalQoS,
                                                          const UROS2QoS InResultQoS,
                                                          const UROS2QoS InFeedbackQoS,
-                                                         const UROS2QoS InCancelQoS)
+                                                         const UROS2QoS InCancelQoS,
+                                                         const UROS2QoS InStatusQoS)
 {
     UROS2ActionServer* server = NewObject<UROS2ActionServer>(InOwner);
     server->ActionClass = InActionClass;
@@ -21,6 +22,7 @@ UROS2ActionServer* UROS2ActionServer::CreateActionServer(UObject* InOwner,
     server->GoalQoS = InGoalQoS;
     server->ResultQoS = InResultQoS;
     server->CancelQoS = InCancelQoS;
+    server->StatusQoS = InStatusQoS;
     server->SetDelegates(InGoalDelegate, InCancelDelegate, InResultDelegate);
     return server;
 }
@@ -36,7 +38,7 @@ void UROS2ActionServer::InitializeActionComponent()
     server_opt.result_service_qos = QoS_LUT[ResultQoS];
     server_opt.cancel_service_qos = QoS_LUT[CancelQoS];
     server_opt.feedback_topic_qos = QoS_LUT[FeedbackQoS];
-    server_opt.status_topic_qos = QoS_LUT[UROS2QoS::Default];    // status is not supported yet.
+    server_opt.status_topic_qos = QoS_LUT[StatusQoS];
 
     rcl_allocator_t allocator = rcl_get_default_allocator();
     RCSOFTCHECK(rcl_ros_clock_init(&ros_clock, &allocator));

--- a/Source/rclUE/Private/ROS2NodeComponent.cpp
+++ b/Source/rclUE/Private/ROS2NodeComponent.cpp
@@ -346,7 +346,8 @@ UROS2ActionClient* UROS2NodeComponent::CreateActionClient(const FString& InActio
                                                           const UROS2QoS InGoalQoS,
                                                           const UROS2QoS InResultQoS,
                                                           const UROS2QoS InFeedbackQoS,
-                                                          const UROS2QoS InCancelQoS)
+                                                          const UROS2QoS InCancelQoS,
+                                                          const UROS2QoS InStatusQoS)
 {
     UROS2ActionClient* client = NewObject<UROS2ActionClient>(this);
     client->ActionClass = InActionClass;
@@ -355,6 +356,7 @@ UROS2ActionClient* UROS2NodeComponent::CreateActionClient(const FString& InActio
     client->ResultQoS = InResultQoS;
     client->FeedbackQoS = InFeedbackQoS;
     client->CancelQoS = InCancelQoS;
+    client->StatusQoS = InStatusQoS;
     client->SetDelegates(InFeedbackDelegate, InResultResponseDelegate, InGoalResponseDelegate, InCancelResponseDelegate);
     AddActionClient(client);
     return client;
@@ -390,7 +392,8 @@ UROS2ActionServer* UROS2NodeComponent::CreateActionServer(const FString& InActio
                                                           const UROS2QoS InGoalQoS,
                                                           const UROS2QoS InResultQoS,
                                                           const UROS2QoS InFeedbackQoS,
-                                                          const UROS2QoS InCancelQoS)
+                                                          const UROS2QoS InCancelQoS,
+                                                          const UROS2QoS InStatusQoS)
 {
     UROS2ActionServer* server = NewObject<UROS2ActionServer>(this);
     server->ActionClass = InActionClass;
@@ -399,6 +402,7 @@ UROS2ActionServer* UROS2NodeComponent::CreateActionServer(const FString& InActio
     server->ResultQoS = InResultQoS;
     server->FeedbackQoS = InFeedbackQoS;
     server->CancelQoS = InCancelQoS;
+    server->StatusQoS = InStatusQoS;
     server->SetDelegates(InGoalDelegate, InCancelDelegate, InResultDelegate);
     AddActionServer(server);
     return server;

--- a/Source/rclUE/Public/ROS2Action.h
+++ b/Source/rclUE/Public/ROS2Action.h
@@ -123,6 +123,10 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     UROS2QoS FeedbackQoS = UROS2QoS::Default;
 
+    //! Quality of Status
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    UROS2QoS StatusQoS = UROS2QoS::ActionStatus;
+
 protected:
     /**
      * @brief Initialize ROS2 Action. Should be implemented in #UROS2ActionServer and #UROS2ActionClient

--- a/Source/rclUE/Public/ROS2ActionClient.h
+++ b/Source/rclUE/Public/ROS2ActionClient.h
@@ -50,7 +50,8 @@ public:
                                                  const UROS2QoS InGoalQoS = UROS2QoS::Services,
                                                  const UROS2QoS InResultQoS = UROS2QoS::Services,
                                                  const UROS2QoS InFeedbackQoS = UROS2QoS::Default,
-                                                 const UROS2QoS InCancelQoS = UROS2QoS::Services);
+                                                 const UROS2QoS InCancelQoS = UROS2QoS::Services,
+                                                 const UROS2QoS InStatusQoS = UROS2QoS::ActionStatus);
     /**
      * @brief Destroy action client from rclc
      *
@@ -181,6 +182,10 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     UROS2QoS FeedbackQoS = UROS2QoS::Default;
 
+    //! this is pass to #UROS2ActionClient::StatusQoS in #BeginPlay
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    UROS2QoS StatusQoS = UROS2QoS::ActionStatus;
+
     FActionCallback GoalResponseDelegate;
     FActionCallback ResultResponseDelegate;
     FActionCallback FeedbackDelegate;
@@ -201,7 +206,8 @@ public:
                                                                  GoalQoS,
                                                                  ResultQoS,
                                                                  FeedbackQoS,
-                                                                 CancelQoS);
+                                                                 CancelQoS,
+                                                                 StatusQoS);
         }
     }
 

--- a/Source/rclUE/Public/ROS2ActionServer.h
+++ b/Source/rclUE/Public/ROS2ActionServer.h
@@ -153,7 +153,7 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     UROS2QoS FeedbackQoS = UROS2QoS::Default;
 
-    //! this is pass to #UROS2ActionServer::FeedbackQoS in #BeginPlay
+    //! this is pass to #UROS2ActionServer::StatusQoS in #BeginPlay
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     UROS2QoS StatusQoS = UROS2QoS::ActionStatus;
 

--- a/Source/rclUE/Public/ROS2ActionServer.h
+++ b/Source/rclUE/Public/ROS2ActionServer.h
@@ -38,7 +38,8 @@ public:
                                                  const UROS2QoS InGoalQoS = UROS2QoS::Services,
                                                  const UROS2QoS InResultQoS = UROS2QoS::Services,
                                                  const UROS2QoS InFeedbackQoS = UROS2QoS::Default,
-                                                 const UROS2QoS InCancelQoS = UROS2QoS::Services);
+                                                 const UROS2QoS InCancelQoS = UROS2QoS::Services,
+                                                 const UROS2QoS InStatusQoS = UROS2QoS::ActionStatus);
 
     /**
      * @brief Destroy action server from rclc
@@ -152,6 +153,10 @@ public:
     UPROPERTY(EditAnywhere, BlueprintReadWrite)
     UROS2QoS FeedbackQoS = UROS2QoS::Default;
 
+    //! this is pass to #UROS2ActionServer::FeedbackQoS in #BeginPlay
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+    UROS2QoS StatusQoS = UROS2QoS::ActionStatus;
+
     FActionCallback GoalDelegate;
     FSimpleCallback ResultDelegate;
     FSimpleCallback CancelDelegate;
@@ -170,7 +175,8 @@ public:
                                                                  GoalQoS,
                                                                  ResultQoS,
                                                                  FeedbackQoS,
-                                                                 CancelQoS);
+                                                                 CancelQoS,
+                                                                 StatusQoS);
         }
     }
 

--- a/Source/rclUE/Public/ROS2NodeComponent.h
+++ b/Source/rclUE/Public/ROS2NodeComponent.h
@@ -263,31 +263,33 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FServiceCallback, UROS2GenericSrv*, InService 
  * @param InResultQoS pass to #UROS2NodeComponent::CreateActionClient
  * @param InFeedbackQoS pass to #UROS2NodeComponent::CreateActionClient
  * @param InCancelQoS pass to #UROS2NodeComponent::CreateActionClient
+ * @param InStatusQoS pass to #UROS2NodeComponent::CreateActionClient
  * @param OutClient return value of #UROS2NodeComponent::CreateActionClient
  */
-#define ROS2_CREATE_ACTION_CLIENT_WITH_QOS(InROS2Node,                                                                        \
-                                           InUserObject,                                                                      \
-                                           InActionName,                                                                      \
-                                           InActionClass,                                                                     \
-                                           InGoalResponseDelegate,                                                            \
-                                           InResultResponseDelegate,                                                          \
-                                           InFeedbackDelegate,                                                                \
-                                           InCancelResponseDelegate,                                                          \
-                                           InGoalQoS,                                                                         \
-                                           InResultQoS,                                                                       \
-                                           InFeedbackQoS,                                                                     \
-                                           InCancelQoS,                                                                       \
-                                           OutClient)                                                                         \
-    if (ensure(IsValid(InROS2Node)))                                                                                          \
-    {                                                                                                                         \
-        FActionCallback Feedback, Result, Goal;                                                                               \
-        FSimpleCallback Cancel;                                                                                               \
-        Goal.BindDynamic(InUserObject, InGoalResponseDelegate);                                                               \
-        Result.BindDynamic(InUserObject, InResultResponseDelegate);                                                           \
-        Feedback.BindDynamic(InUserObject, InFeedbackDelegate);                                                               \
-        Cancel.BindDynamic(InUserObject, InCancelResponseDelegate);                                                           \
-        OutClient = InROS2Node->CreateActionClient(                                                                           \
-            InActionName, InActionClass, Goal, Result, Feedback, Cancel, InGoalQoS, InResultQoS, InFeedbackQoS, InCancelQoS); \
+#define ROS2_CREATE_ACTION_CLIENT_WITH_QOS(InROS2Node,                                                                                      \
+                                           InUserObject,                                                                                    \
+                                           InActionName,                                                                                    \
+                                           InActionClass,                                                                                   \
+                                           InGoalResponseDelegate,                                                                          \
+                                           InResultResponseDelegate,                                                                        \
+                                           InFeedbackDelegate,                                                                              \
+                                           InCancelResponseDelegate,                                                                        \
+                                           InGoalQoS,                                                                                       \
+                                           InResultQoS,                                                                                     \
+                                           InFeedbackQoS,                                                                                   \
+                                           InCancelQoS,                                                                                     \
+                                           InStatusQoS,                                                                                     \
+                                           OutClient)                                                                                       \
+    if (ensure(IsValid(InROS2Node)))                                                                                                        \
+    {                                                                                                                                       \
+        FActionCallback Feedback, Result, Goal;                                                                                             \
+        FSimpleCallback Cancel;                                                                                                             \
+        Goal.BindDynamic(InUserObject, InGoalResponseDelegate);                                                                             \
+        Result.BindDynamic(InUserObject, InResultResponseDelegate);                                                                         \
+        Feedback.BindDynamic(InUserObject, InFeedbackDelegate);                                                                             \
+        Cancel.BindDynamic(InUserObject, InCancelResponseDelegate);                                                                         \
+        OutClient = InROS2Node->CreateActionClient(                                                                                         \
+            InActionName, InActionClass, Goal, Result, Feedback, Cancel, InGoalQoS, InResultQoS, InFeedbackQoS, InCancelQoS, InStatusQoS);  \
     }
 
 /**
@@ -332,29 +334,31 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FServiceCallback, UROS2GenericSrv*, InService 
  * @param InResultQoS pass to #UROS2NodeComponent::CreateActionServer
  * @param InFeedbackQoS pass to #UROS2NodeComponent::CreateActionServer
  * @param InCancelQoS pass to #UROS2NodeComponent::CreateActionServer
+ * @param InStatusQoS pass to #UROS2NodeComponent::CreateActionServer
  * @param OutServer return value of #UROS2NodeComponent::CreateActionServer
  */
-#define ROS2_CREATE_ACTION_SERVER_WITH_QOS(InROS2Node,                                                              \
-                                           InUserObject,                                                            \
-                                           InActionName,                                                            \
-                                           InActionClass,                                                           \
-                                           InGoalDelegate,                                                          \
-                                           InResultDelegate,                                                        \
-                                           InCancelDelegate,                                                        \
-                                           InGoalQoS,                                                               \
-                                           InResultQoS,                                                             \
-                                           InFeedbackQoS,                                                           \
-                                           InCancelQoS,                                                             \
-                                           OutServer)                                                               \
-    if (ensure(IsValid(InROS2Node)))                                                                                \
-    {                                                                                                               \
-        FActionCallback Goal;                                                                                       \
-        FSimpleCallback Result, Cancel;                                                                             \
-        Goal.BindDynamic(InUserObject, InGoalDelegate);                                                             \
-        Result.BindDynamic(InUserObject, InResultDelegate);                                                         \
-        Cancel.BindDynamic(InUserObject, InCancelDelegate);                                                         \
-        OutServer = InROS2Node->CreateActionServer(                                                                 \
-            InActionName, InActionClass, Goal, Result, Cancel, InGoalQoS, InResultQoS, InFeedbackQoS, InCancelQoS); \
+#define ROS2_CREATE_ACTION_SERVER_WITH_QOS(InROS2Node,                                                                              \
+                                           InUserObject,                                                                            \
+                                           InActionName,                                                                            \
+                                           InActionClass,                                                                           \
+                                           InGoalDelegate,                                                                          \
+                                           InResultDelegate,                                                                        \
+                                           InCancelDelegate,                                                                        \
+                                           InGoalQoS,                                                                               \
+                                           InResultQoS,                                                                             \
+                                           InFeedbackQoS,                                                                           \
+                                           InCancelQoS,                                                                             \
+                                           InStatusQoS,                                                                             \
+                                           OutServer)                                                                               \
+    if (ensure(IsValid(InROS2Node)))                                                                                                \
+    {                                                                                                                               \
+        FActionCallback Goal;                                                                                                       \
+        FSimpleCallback Result, Cancel;                                                                                             \
+        Goal.BindDynamic(InUserObject, InGoalDelegate);                                                                             \
+        Result.BindDynamic(InUserObject, InResultDelegate);                                                                         \
+        Cancel.BindDynamic(InUserObject, InCancelDelegate);                                                                         \
+        OutServer = InROS2Node->CreateActionServer(                                                                                 \
+            InActionName, InActionClass, Goal, Result, Cancel, InGoalQoS, InResultQoS, InFeedbackQoS, InCancelQoS, InStatusQoS);    \
     }
 
 /**
@@ -594,6 +598,7 @@ public:
      * @param InResultQoS
      * @param InGoalQoS
      * @param InCancelQoS
+     * @param InStatusQoS
      * @return UROS2ActionClient*
      */
     UROS2ActionClient* CreateActionClient(const FString& InActionName,
@@ -605,7 +610,8 @@ public:
                                           const UROS2QoS InGoalQoS = UROS2QoS::Services,
                                           const UROS2QoS InResultQoS = UROS2QoS::Services,
                                           const UROS2QoS InFeedbackQoS = UROS2QoS::Default,
-                                          const UROS2QoS InCancelQoS = UROS2QoS::Services);
+                                          const UROS2QoS InCancelQoS = UROS2QoS::Services,
+                                          const UROS2QoS InStatusQoS = UROS2QoS::ActionStatus);
     /**
      * @brief Set this node to #UROS2ActionClient::OwnerNode and add to #ActionServers.
      *
@@ -626,6 +632,7 @@ public:
      * @param InResultQoS
      * @param InGoalQoS
      * @param InCancelQoS
+     * @param InStatusQoS
      * @return UROS2ActionServer*
      */
     UROS2ActionServer* CreateActionServer(const FString& InActionName,
@@ -636,7 +643,8 @@ public:
                                           const UROS2QoS InGoalQoS = UROS2QoS::Services,
                                           const UROS2QoS InResultQoS = UROS2QoS::Services,
                                           const UROS2QoS InFeedbackQoS = UROS2QoS::Default,
-                                          const UROS2QoS InCancelQoS = UROS2QoS::Services);
+                                          const UROS2QoS InCancelQoS = UROS2QoS::Services,
+                                          const UROS2QoS InStatusQoS = UROS2QoS::ActionStatus);
 
     //! Node state
     UPROPERTY(VisibleAnywhere, BlueprintReadOnly)

--- a/Source/rclUE/Public/rclcUtilities.h
+++ b/Source/rclUE/Public/rclcUtilities.h
@@ -17,7 +17,7 @@
 #include "Kismet/GameplayStatics.h"
 #include "Kismet/KismetSystemLibrary.h"
 #include "UObject/Object.h"
-#include "Misc/EngineVersionComparison.h" 
+#include "Misc/EngineVersionComparison.h"
 
 #if UE_VERSION_NEWER_THAN(5, 5, 0)
 #include "Misc/App.h"
@@ -102,6 +102,7 @@ enum class UROS2QoS : uint8
     ParameterEvents UMETA(DisplayName = "ParameterEvents"),
     System UMETA(DisplayName = "System"),
     UnknownQoS UMETA(DisplayName = "UnknownQoS"),
+    ActionStatus UMETA(DisplayName = "ActionStatus"),
 };
 
 //! profiles provided by rclUE
@@ -159,6 +160,17 @@ static const rmw_qos_profile_t rclUE_qos_profile_static_broadcaster = {RMW_QOS_P
                                                                        RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
                                                                        false};
 
+//! profiles provided by rclUE
+static const rmw_qos_profile_t rclUE_qos_profile_action_status = { RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+                                                            10,
+                                                            RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+                                                            RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+                                                            RMW_QOS_DEADLINE_DEFAULT,
+                                                            RMW_QOS_LIFESPAN_DEFAULT,
+                                                            RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT,
+                                                            RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
+                                                            false};
+
 //! Look-Up Table matching enum with rcl profiles
 static const TMap<UROS2QoS, rmw_qos_profile_t> QoS_LUT = {{UROS2QoS::Default, rmw_qos_profile_default},
                                                           {UROS2QoS::SensorData, rclUE_qos_profile_sensor_data},
@@ -170,7 +182,8 @@ static const TMap<UROS2QoS, rmw_qos_profile_t> QoS_LUT = {{UROS2QoS::Default, rm
                                                           {UROS2QoS::Services, rmw_qos_profile_services_default},
                                                           {UROS2QoS::ParameterEvents, rmw_qos_profile_parameter_events},
                                                           {UROS2QoS::System, rmw_qos_profile_system_default},
-                                                          {UROS2QoS::UnknownQoS, rmw_qos_profile_unknown}};
+                                                          {UROS2QoS::UnknownQoS, rmw_qos_profile_unknown},
+                                                          {UROS2QoS::ActionStatus, rclUE_qos_profile_action_status}};
 
 /**
  * @brief Custom timer manager.  This try to execute delegate at a given fixed rate.


### PR DESCRIPTION
Add support for action status

- Add rclUE_qos_profile_action_status
- Add InStatusQoS argument to Action Server/Client and ROS2NodeComponent constructors
- Implement action status handling in ROS2ActionClient

Also included related PR to support copying the goal ID into the result request: https://github.com/rapyuta-robotics/UE_tools/pull/33

Tested on Ubuntu 22.04, UE 5.5, ROS 2 Humble. Confirmed interoperability with external action servers and clients.

Related to #154 